### PR TITLE
Slightly more verbose logging when assign types don't match

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ go:
 before_install:
   - go get -v github.com/golang/lint/golint
   - go get -v golang.org/x/tools/cmd/cover
-  - go get -v golang.org/x/tools/cmd/vet
 
 install:
   - go install -race -v std

--- a/inject.go
+++ b/inject.go
@@ -273,10 +273,11 @@ StructLoop:
 
 			if !existing.reflectType.AssignableTo(fieldType) {
 				return fmt.Errorf(
-					"object named %s of type %s is not assignable to field %s in type %s",
+					"object named %s of type %s is not assignable to field %s (%s) in type %s",
 					tag.Name,
 					fieldType,
 					o.reflectType.Elem().Field(i).Name,
+					existing.reflectType,
 					o.reflectType,
 				)
 			}

--- a/inject_test.go
+++ b/inject_test.go
@@ -442,7 +442,7 @@ func TestInvalidNamedInstanceType(t *testing.T) {
 		t.Fatal("did not find expected error")
 	}
 
-	const msg = "object named foo of type *inject_test.TypeNestedStruct is not assignable to field A in type *inject_test.TypeWithInvalidNamedType"
+	const msg = "object named foo of type *inject_test.TypeNestedStruct is not assignable to field A (*inject_test.TypeAnswerStruct) in type *inject_test.TypeWithInvalidNamedType"
 	if err.Error() != msg {
 		t.Fatalf("expected:\n%s\nactual:\n%s", msg, err.Error())
 	}


### PR DESCRIPTION
I found this handy when I was injecting named value types and the types were not matching.