### PR TITLE
don't panic when injecting nil

### DIFF
--- a/inject.go
+++ b/inject.go
@@ -563,7 +563,7 @@ func parseTag(t string) (*tag, error) {
 }
 
 func isStructPtr(t reflect.Type) bool {
-	return t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Struct
+	return t != nil && t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Struct
 }
 
 func isNilOrZero(v reflect.Value, t reflect.Type) bool {

--- a/inject_test.go
+++ b/inject_test.go
@@ -994,3 +994,13 @@ func TestForSameNameButDifferentPackage(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestInjectNil(t *testing.T) {
+	var g inject.Graph
+	err := g.Provide(
+		&inject.Object{Value: nil},
+	)
+	if err == nil {
+		t.Fatal("expected error when injecting nil")
+	}
+}


### PR DESCRIPTION
I think the error message: "expected unnamed object value to be a pointer to a struct but got type %!s(<nil>) with value <nil>" is slightly better than the current behavior which is to panic when injecting nil.