### PR TITLE
feat(inject): Allow custom initialization of structs

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -34,11 +34,18 @@ type NameAPI struct {
 	// hence must be explicitly provided to the graph.
 
 	HTTPTransport http.RoundTripper `inject:""`
+
+	// This initialized in the Init func
+	name string
+}
+
+func (n *NameAPI) Init() {
+	n.name = "Spock"
 }
 
 func (n *NameAPI) Name(id uint64) string {
 	// in the real world we would use f.HTTPTransport and fetch the name
-	return "Spock"
+	return n.name
 }
 
 // Our fake Planet API.

--- a/inject.go
+++ b/inject.go
@@ -206,6 +206,18 @@ func (g *Graph) Populate() error {
 		}
 	}
 
+	// Finally, optionally call the Init method for any domain specific initialization
+	for _, o := range g.Objects() {
+		method, exists := o.reflectType.MethodByName("Init")
+		if exists {
+			if g.Logger != nil {
+				g.Logger.Debugf("initializing %s", o)
+			}
+			method.Func.Call([]reflect.Value{o.reflectValue})
+		}
+
+	}
+
 	return nil
 }
 

--- a/inject_test.go
+++ b/inject_test.go
@@ -994,3 +994,29 @@ func TestForSameNameButDifferentPackage(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+type TypeForIniting struct {
+	n int
+}
+
+func (t *TypeForIniting) Init() {
+	t.n = 78
+}
+
+func TestInitingStruct(t *testing.T) {
+	var g inject.Graph
+	var s TypeForIniting
+	err := g.Provide(
+		&inject.Object{Value: &s},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Populate(); err != nil {
+		t.Fatal(err)
+	}
+
+	if 78 != s.n {
+		t.Fatal("Did not initialize struct with Init() func")
+	}
+}


### PR DESCRIPTION
A custom func `Init()` may be provided for a struct to perform
custom initialization. This includes setting fields that are private
(and not part of the inject graph).